### PR TITLE
Update version and checksums

### DIFF
--- a/www/cadaver/Portfile
+++ b/www/cadaver/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                cadaver
-version             0.24
+version             0.28
 revision            0
 categories          www
 maintainers         {fossekall.de:michael.klein @mklein-de} openmaintainer
@@ -18,9 +18,9 @@ license             GPL-2
 
 master_sites        ${homepage}
 
-checksums           rmd160 8efe1502d0be32baaa88eb7a9c15cfaff88e27bd \
-                    sha256 46cff2f3ebd32cd32836812ca47bcc75353fc2be757f093da88c0dd8f10fd5f6 \
-                    size 808069
+checksums           rmd160 f0db222682fa431522731909cfd56e52bd95ee0a \
+                    sha256 33e3a54bd54b1eb325b48316a7cacc24047c533ef88e6ef98b88dfbb60e12734 \
+                    size 1073003
 
 depends_build       port:pkgconfig
 depends_lib         path:lib/libssl.dylib:openssl \


### PR DESCRIPTION
Update version and checksums for v0.28

Closes: https://trac.macports.org/ticket/72814

#### Description

Update Portfile for new version

###### Type(s)

Version update

###### Tested on
macOS 15.7.7 24G720 arm64
Xcode 26.3 17C529

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? 
- [x] checked your Portfile with `port lint`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
